### PR TITLE
ci: configure golangci-lint to exclude test files from errcheck

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,8 @@
+version: "2"
+
+issues:
+  exclude-rules:
+    # Exclude test files from errcheck linter
+    - path: "_test\\.go$"
+      linters:
+        - errcheck

--- a/handler_test.go
+++ b/handler_test.go
@@ -25,7 +25,7 @@ func (m mockResponse) Render(w http.ResponseWriter, r *http.Request) error {
 		return m.renderErr
 	}
 	w.WriteHeader(m.statusCode)
-	w.Write([]byte(m.body))
+	_, _ = w.Write([]byte(m.body))
 	return nil
 }
 
@@ -146,7 +146,7 @@ func TestWrap(t *testing.T) {
 			errorHandlerCalled = true
 			assert.Equal(t, binderErr, err)
 			ctx.ResponseWriter().WriteHeader(http.StatusBadRequest)
-			ctx.ResponseWriter().Write([]byte("custom error: " + err.Error()))
+			_, _ = ctx.ResponseWriter().Write([]byte("custom error: " + err.Error()))
 		}
 
 		handler := saaskit.HandlerFunc[saaskit.Context, string](func(ctx saaskit.Context, req string) saaskit.Response {
@@ -196,7 +196,7 @@ func TestWrap(t *testing.T) {
 		customErrorHandler := func(ctx saaskit.Context, err error) {
 			capturedErr = err
 			ctx.ResponseWriter().WriteHeader(http.StatusServiceUnavailable)
-			ctx.ResponseWriter().Write([]byte("service unavailable"))
+			_, _ = ctx.ResponseWriter().Write([]byte("service unavailable"))
 		}
 
 		handler := saaskit.HandlerFunc[saaskit.Context, string](func(ctx saaskit.Context, req string) saaskit.Response {


### PR DESCRIPTION
Add .golangci.yml configuration to exclude test files from errcheck linter to avoid false positives for unchecked errors in test code