### PR TITLE
fix: remove fmt.Printf warnings in i18n adapters

### DIFF
--- a/pkg/i18n/adapters.go
+++ b/pkg/i18n/adapters.go
@@ -213,7 +213,6 @@ func (a *DirectoryAdapter) processDirectory(ctx context.Context, allTranslations
 		err := a.processFile(ctx, filePath, allTranslations)
 		if err != nil {
 			// Continue processing other files for resilient loading
-			fmt.Printf("Warning: failed to process file '%s': %v\n", filePath, err)
 			continue
 		}
 	}
@@ -344,8 +343,7 @@ func (a *EmbeddedFsAdapter) Load(ctx context.Context) (map[string]map[string]any
 
 		// Process the file and merge translations
 		if err := a.processFile(ctx, filePath, allTranslations); err != nil {
-			// Log the error but continue processing other files
-			fmt.Printf("Warning: failed to process file '%s': %v\n", filePath, err)
+			// Continue processing other files for resilient loading
 			continue
 		}
 


### PR DESCRIPTION
Remove inappropriate use of fmt.Printf for logging warnings in resilient loading scenarios. The warnings were polluting stdout and not following Go best practices for library code.

The adapters already handle errors gracefully by continuing processing other files, so the warnings were redundant.

🤖 Generated with [Claude Code](https://claude.ai/code)